### PR TITLE
Changed naming from 'active' to 'current'.

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -102,13 +102,22 @@ export class Staker extends Entity {
     this.set("id", Value.fromString(value));
   }
 
-  get activeRETHBalance(): BigInt {
-    let value = this.get("activeRETHBalance");
+  get currentRETHBalance(): BigInt {
+    let value = this.get("currentRETHBalance");
     return value.toBigInt();
   }
 
-  set activeRETHBalance(value: BigInt) {
-    this.set("activeRETHBalance", Value.fromBigInt(value));
+  set currentRETHBalance(value: BigInt) {
+    this.set("currentRETHBalance", Value.fromBigInt(value));
+  }
+
+  get currentETHBalance(): BigInt {
+    let value = this.get("currentETHBalance");
+    return value.toBigInt();
+  }
+
+  set currentETHBalance(value: BigInt) {
+    this.set("currentETHBalance", Value.fromBigInt(value));
   }
 
   get totalETHRewards(): BigInt {

--- a/schema.graphql
+++ b/schema.graphql
@@ -15,13 +15,16 @@ type Staker @entity {
   # Address that holds rETH.
   id: ID! 
 
-  # Active rETH balance. (Based on last checkpoint & including all transactions that have passed)
-  activeRETHBalance: BigInt!
+  # Current rETH balance. (Based on last checkpoint & including all transactions that have passed)
+  currentRETHBalance: BigInt!
 
-  # Total ETH rewards.
+  # Current ETH balance. (Based on the current rETH balance and the current rETH:ETH exchange rate)
+  currentETHBalance: BigInt!
+
+  # Total ETH rewards accrued over all staker balance checkpoints.
   totalETHRewards: BigInt!
 
-  # The last known staker balance checkpoint
+  # The last known staker balance checkpoint for this staker.
   lastBalanceCheckpoint: StakerBalanceCheckpoint
 
   # Block number at which this staker first received rETH.

--- a/src/entityfactory.ts
+++ b/src/entityfactory.ts
@@ -116,7 +116,8 @@ class RocketPoolEntityFactory {
     staker.block = blockNumber
     staker.blockTime = blockTime
     staker.lastBalanceCheckpoint = null
-    staker.activeRETHBalance = BigInt.fromI32(0)
+    staker.currentRETHBalance = BigInt.fromI32(0)
+    staker.currentETHBalance = BigInt.fromI32(0)
     staker.totalETHRewards = BigInt.fromI32(0)
 
     // Return our new Staker.

--- a/src/entityutilities.ts
+++ b/src/entityutilities.ts
@@ -96,14 +96,19 @@ class RocketEntityUtilities {
   /**
    * Changes the balance for a staker, with the amount and either a minus or a plus operation.
    */
-  public changeStakerBalance(staker: Staker, rEthAmount: BigInt, increase: boolean) : void {
+  public changeStakerBalances(staker: Staker, rEthAmount: BigInt, rEthExchangeRate : BigInt, increase: boolean) : void {
     if(staker === null) return;
 
-    if (increase) staker.activeRETHBalance = staker.activeRETHBalance.plus(rEthAmount);
+    // Set current rETH balance.
+    if (increase) staker.currentRETHBalance = staker.currentRETHBalance.plus(rEthAmount);
     else {
-      if (staker.activeRETHBalance >= rEthAmount) staker.activeRETHBalance = staker.activeRETHBalance.minus(rEthAmount);
-      else staker.activeRETHBalance = BigInt.fromI32(0); // Could be zero address.
+      if (staker.currentRETHBalance >= rEthAmount) staker.currentRETHBalance = staker.currentRETHBalance.minus(rEthAmount);
+      else staker.currentRETHBalance = BigInt.fromI32(0); // Could be zero address.
     }
+
+    // Set current ETH balance.
+    if (rEthExchangeRate > BigInt.fromI32(0) && rEthAmount > BigInt.fromI32(0)) staker.currentETHBalance = staker.currentRETHBalance.times(rEthExchangeRate);
+    else staker.currentETHBalance = BigInt.fromI32(0);
   }
 
   /**

--- a/src/mappings/rocketNetworkBalancesMapping.ts
+++ b/src/mappings/rocketNetworkBalancesMapping.ts
@@ -106,22 +106,22 @@ function generateStakerBalanceCheckpoints(
      * These stakers will keep their last checkpoint link & total rewards. (if they had any)
      */
     let staker = Staker.load(stakerId)
-    if (staker === null || staker.activeRETHBalance === BigInt.fromI32(0))
+    if (staker === null || staker.currentRETHBalance === BigInt.fromI32(0))
       return
 
-    // Store the active balances in temporary variables. This will make everything easier to read.
-    let activeRETHBalance = staker.activeRETHBalance
-    if (activeRETHBalance < BigInt.fromI32(0))
-      activeRETHBalance = BigInt.fromI32(0)
-    let activeETHBalance = activeRETHBalance.times(
+    // Store the current balances in temporary variables. This will make everything easier to read.
+    let currentRETHBalance = staker.currentRETHBalance
+    if (currentRETHBalance < BigInt.fromI32(0))
+      currentRETHBalance = BigInt.fromI32(0)
+    let currentETHBalance = currentRETHBalance.times(
       networkBalanceCheckpoint.rEthExchangeRate,
     )
-    if (activeETHBalance < BigInt.fromI32(0))
-      activeETHBalance = BigInt.fromI32(0)
+    if (currentETHBalance < BigInt.fromI32(0))
+      currentETHBalance = BigInt.fromI32(0)
 
     // By default, assume the previous (r)ETH balances are the same as the current ones.
-    let previousRETHBalance = activeRETHBalance
-    let previousETHBalance = activeETHBalance
+    let previousRETHBalance = currentRETHBalance
+    let previousETHBalance = currentETHBalance
 
     // If we had a previous staker balance checkpoint, then use the balances from that link.
     if (staker.lastBalanceCheckpoint !== null) {
@@ -140,8 +140,8 @@ function generateStakerBalanceCheckpoints(
 
     // This will indicate how many ETH rewards we have since the previous checkpoint.
     let ethRewardsSincePreviousCheckpoint = rocketEntityUtilities.getETHRewardsSincePreviousStakerBalanceCheckpoint(
-      activeRETHBalance,
-      activeETHBalance,
+      currentRETHBalance,
+      currentETHBalance,
       previousRETHBalance,
       previousETHBalance,
     )
@@ -151,8 +151,8 @@ function generateStakerBalanceCheckpoints(
       stakerBalanceCheckpointId,
       staker,
       networkBalanceCheckpoint,
-      activeETHBalance,
-      activeRETHBalance,
+      currentETHBalance,
+      currentRETHBalance,
       ethRewardsSincePreviousCheckpoint,
       blockNumber,
       blockTime,

--- a/src/mappings/rocketTokenRETHMapping.ts
+++ b/src/mappings/rocketTokenRETHMapping.ts
@@ -1,10 +1,11 @@
-import { ADDRESS_ZERO } from '../constants'
+import { ADDRESS_ZERO, ADDRESS_ROCKET_TOKEN_RETH } from '../constants'
 import { Address, BigInt } from '@graphprotocol/graph-ts'
 import {
   TokensBurned,
   TokensMinted,
   Transfer,
 } from '../../generated/rocketTokenRETH/rocketTokenRETH'
+import { rocketTokenRETH } from '../../generated/rocketNetworkBalances/rocketTokenRETH'
 import { Staker } from '../../generated/schema'
 import { rocketEntityUtilities } from '../entityutilities'
 import { rocketPoolEntityFactory } from '../entityfactory'
@@ -116,9 +117,13 @@ function saveTransaction(
     protocol.save()
   }
 
+ // Load the RocketTokenRETH contract.
+ let rocketTokenRETHContract = rocketTokenRETH.bind(ADDRESS_ROCKET_TOKEN_RETH)
+ if (rocketTokenRETHContract === null) return
+
   // Update active balances for stakesr.
-  rocketEntityUtilities.changeStakerBalance(fromStaker, rEthAmount, false);
-  rocketEntityUtilities.changeStakerBalance(toStaker, rEthAmount, true);
+  rocketEntityUtilities.changeStakerBalances(fromStaker, rEthAmount, rocketTokenRETHContract.getExchangeRate(), false);
+  rocketEntityUtilities.changeStakerBalances(toStaker, rEthAmount, rocketTokenRETHContract.getExchangeRate(), true);
 
   // Save all affected entities.
   fromStaker.save()


### PR DESCRIPTION
This will be easier to understand and we will have less conflicts when using the same mechanics with other entities that use 'active' in one or more contract function names.

Also added the currentETH balance for the staker.