### PR TITLE
Update to repo for 0.22.0 CLI upgrade

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -4,7 +4,7 @@ type RocketPoolProtocol @entity {
   id: ID! 
 
   # All stakers (addresses holding rETH) associated with the RocketPool protocol.
-  stakers: [Staker]!
+  stakers: [Staker!]!
 
   # Last known staker network balance checkpoint.
   lastNetworkStakerBalanceCheckPoint: NetworkStakerBalanceCheckpoint

--- a/src/entityutilities.ts
+++ b/src/entityutilities.ts
@@ -186,8 +186,8 @@ class RocketEntityUtilities {
 }
 
 export class TransactionStakers {
-  fromStaker: Staker
-  toStaker: Staker
+  fromStaker!: Staker
+  toStaker!: Staker
 }
 
 export class NetworkStakerRewardCheckpointSummary {

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -11,7 +11,7 @@ dataSources:
       startBlock: 5200000
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.5
       language: wasm/assemblyscript
       entities:
         - Staker
@@ -33,7 +33,7 @@ dataSources:
       startBlock: 5200000
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.5
       language: wasm/assemblyscript
       entities:
         - Staker


### PR DESCRIPTION
With the upgrade to the graph's CLI it is now utilizing Assembly Script V0.19.10 rather than the archaic version v0.6.

This upgrade includes a few breaking changes to the existing codebase. 

Migration information can be found here.
https://thegraph.com/docs/developer/assemblyscript-migration-guide